### PR TITLE
feat: review type switch widget

### DIFF
--- a/lib/models/review_type.dart
+++ b/lib/models/review_type.dart
@@ -1,0 +1,19 @@
+enum ReviewType {
+  consulting,
+  matching;
+
+  ReviewType get inversed {
+    return switch (this) {
+      ReviewType.consulting => ReviewType.matching,
+      ReviewType.matching => ReviewType.consulting
+    };
+  }
+
+  @override
+  String toString() {
+    return switch (this) {
+      ReviewType.consulting => "상담",
+      ReviewType.matching => "매칭"
+    };
+  }
+}

--- a/lib/pages/details_page.dart
+++ b/lib/pages/details_page.dart
@@ -193,7 +193,13 @@ class _DetailsPageState extends ConsumerState<DetailsPage> {
                     ),
                   ),
                   SliverToBoxAdapter(
-                    child: DetailsIntroductionTab(key: keys[0]),
+                    child: Column(
+                      key: keys[0],
+                      children: const [
+                        DetailsIntroductionTab(),
+                        Divider(thickness: 4),
+                      ],
+                    ),
                   ),
                 ];
               },

--- a/lib/widgets/details_introduction_tab.dart
+++ b/lib/widgets/details_introduction_tab.dart
@@ -273,6 +273,7 @@ class DetailsIntroductionTab extends StatelessWidget {
               ],
             ),
           ),
+          const SizedBox(height: 16),
         ],
       ),
     );

--- a/lib/widgets/details_review_tab.dart
+++ b/lib/widgets/details_review_tab.dart
@@ -1,14 +1,21 @@
+import 'package:dears/models/review_type.dart';
 import 'package:dears/widgets/review_input.dart';
 import 'package:dears/widgets/review_list_tile.dart';
+import 'package:dears/widgets/review_type_switch.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
-const int _reviewCount = 3;
+const List<int> _reviewCounts = [3, 7];
+final int _totalReviewCount = _reviewCounts.reduce((a, b) => a + b);
 
-class DetailsReviewTab extends StatelessWidget {
+class DetailsReviewTab extends HookWidget {
   const DetailsReviewTab({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final reviewType = useState(ReviewType.values[0]);
+    final count = _reviewCounts[reviewType.value.index];
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
       child: CustomScrollView(
@@ -18,20 +25,47 @@ class DetailsReviewTab extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const ReviewInput(),
+                const SizedBox(height: 50),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    RichText(
+                      text: TextSpan(
+                        style: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.black,
+                        ),
+                        children: [
+                          const TextSpan(text: "리뷰 "),
+                          TextSpan(
+                            text: "$_totalReviewCount",
+                            style: const TextStyle(color: Colors.blue),
+                          ),
+                        ],
+                      ),
+                    ),
+                    ReviewTypeSwitch(
+                      value: reviewType.value,
+                      onChanged: (value) => reviewType.value = value,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                ReviewInput(type: reviewType.value),
                 const SizedBox(height: 16),
                 RichText(
-                  text: const TextSpan(
-                    style: TextStyle(
+                  text: TextSpan(
+                    style: const TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.bold,
                       color: Colors.black,
                     ),
                     children: [
-                      TextSpan(text: "리뷰 "),
+                      TextSpan(text: "${reviewType.value} 리뷰 "),
                       TextSpan(
-                        text: "$_reviewCount",
-                        style: TextStyle(color: Colors.grey),
+                        text: "$count",
+                        style: const TextStyle(color: Colors.grey),
                       ),
                     ],
                   ),
@@ -41,7 +75,7 @@ class DetailsReviewTab extends StatelessWidget {
             ),
           ),
           SliverList.separated(
-            itemCount: _reviewCount,
+            itemCount: count,
             separatorBuilder: (context, index) => const SizedBox(height: 8),
             itemBuilder: (context, index) => const ReviewListTile(),
           ),

--- a/lib/widgets/review_input.dart
+++ b/lib/widgets/review_input.dart
@@ -1,9 +1,15 @@
+import 'package:dears/models/review_type.dart';
 import 'package:dears/widgets/review_keyword_chips.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
 class ReviewInput extends HookWidget {
-  const ReviewInput({super.key});
+  final ReviewType type;
+
+  const ReviewInput({
+    super.key,
+    required this.type,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -17,11 +23,21 @@ class ReviewInput extends HookWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              const Text(
-                "웨딩플래너\n리뷰를 작성해주세요",
-                style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
+              RichText(
+                text: TextSpan(
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black,
+                  ),
+                  children: [
+                    const TextSpan(text: "웨딩플래너 "),
+                    TextSpan(
+                      text: "$type\n",
+                      style: const TextStyle(color: Colors.blue),
+                    ),
+                    const TextSpan(text: "리뷰를 작성해주세요"),
+                  ],
                 ),
               ),
               Container(

--- a/lib/widgets/review_type_switch.dart
+++ b/lib/widgets/review_type_switch.dart
@@ -1,0 +1,247 @@
+import 'dart:ui';
+
+import 'package:dears/models/review_type.dart';
+import 'package:flutter/material.dart';
+
+const double _trackWidth = 150;
+const double _trackHeight = 36;
+const double _trackRadius = _trackHeight / 2;
+
+const double _thumbWidth = 72;
+const double _thumbHeight = 32;
+const double _thumbRadius = _thumbHeight / 2;
+const double _thumbExtension = 4;
+
+const double _trackPadding = _trackRadius - _thumbRadius;
+const double _trackInnerWidth = _trackWidth - 2 * _trackPadding;
+const double _trackAvailableLength =
+    _trackInnerWidth - (_thumbWidth + _thumbExtension);
+
+const Duration _toggleDuration = Duration(milliseconds: 200);
+const Duration _reactionDuration = Duration(milliseconds: 300);
+
+class ReviewTypeSwitch extends StatefulWidget {
+  final ReviewType value;
+  final ValueChanged<ReviewType> onChanged;
+
+  const ReviewTypeSwitch({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  State<ReviewTypeSwitch> createState() => _ReviewTypeSwitchState();
+}
+
+class _ReviewTypeSwitchState extends State<ReviewTypeSwitch>
+    with TickerProviderStateMixin {
+  late final AnimationController positionController;
+  late final CurvedAnimation position;
+
+  late final AnimationController reactionController;
+  late final CurvedAnimation reaction;
+
+  // A non-null boolean value that changes to true at the end of a drag if the
+  // switch must be animated to the position indicated by the widget's value.
+  bool needsPositionAnimation = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    positionController = AnimationController(
+      vsync: this,
+      duration: _toggleDuration,
+    );
+    position = CurvedAnimation(
+      parent: positionController,
+      curve: Curves.linear,
+    );
+
+    reactionController = AnimationController(
+      vsync: this,
+      duration: _reactionDuration,
+    );
+    reaction = CurvedAnimation(
+      parent: reactionController,
+      curve: Curves.ease,
+    );
+  }
+
+  @override
+  void didUpdateWidget(ReviewTypeSwitch oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (needsPositionAnimation || widget.value != oldWidget.value) {
+      resumePositionAnimation(isLinear: needsPositionAnimation);
+    }
+  }
+
+  @override
+  void dispose() {
+    positionController.dispose();
+    reactionController.dispose();
+
+    super.dispose();
+  }
+
+  // `isLinear` must be true if the position animation is trying to move the
+  // thumb to the closest end after the most recent drag animation, so the curve
+  // does not change when the controller's value is not 0 or 1.
+  //
+  // It can be set to false when it's an implicit animation triggered by
+  // widget.value changes.
+  void resumePositionAnimation({bool isLinear = true}) {
+    needsPositionAnimation = false;
+    position
+      ..curve = isLinear ? Curves.linear : Curves.ease
+      ..reverseCurve = isLinear ? Curves.linear : Curves.ease.flipped;
+    switch (widget.value) {
+      case ReviewType.consulting:
+        positionController.reverse();
+      case ReviewType.matching:
+        positionController.forward();
+    }
+  }
+
+  void onTapDown(TapDownDetails details) {
+    needsPositionAnimation = false;
+    reactionController.forward();
+  }
+
+  void onTapUp(TapUpDetails details) {
+    needsPositionAnimation = false;
+    reactionController.reverse();
+  }
+
+  void onTap() {
+    widget.onChanged(widget.value.inversed);
+  }
+
+  void onTapCancel() {
+    reactionController.reverse();
+  }
+
+  void onHorizontalDragStart(DragStartDetails details) {
+    needsPositionAnimation = false;
+    reactionController.forward();
+  }
+
+  void onHorizontalDragUpdate(DragUpdateDetails details) {
+    position
+      ..curve = Curves.linear
+      ..reverseCurve = Curves.linear;
+
+    final primaryDelta = details.primaryDelta;
+    if (primaryDelta == null) {
+      return;
+    }
+    positionController.value += primaryDelta / _trackAvailableLength;
+  }
+
+  void onHorizontalDragEnd(DragEndDetails details) {
+    // Deferring the animation to the next build phase.
+    setState(() {
+      needsPositionAnimation = true;
+    });
+
+    // Call onChanged when the user's intent to change value is clear.
+    if (position.value >= 0.5 != (widget.value == ReviewType.values.last)) {
+      widget.onChanged(widget.value.inversed);
+    }
+
+    reactionController.reverse();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (needsPositionAnimation) {
+      resumePositionAnimation();
+    }
+
+    return GestureDetector(
+      onTapDown: onTapDown,
+      onTapUp: onTapUp,
+      onTap: onTap,
+      onTapCancel: onTapCancel,
+      onHorizontalDragStart: onHorizontalDragStart,
+      onHorizontalDragUpdate: onHorizontalDragUpdate,
+      onHorizontalDragEnd: onHorizontalDragEnd,
+      child: Container(
+        padding: const EdgeInsets.all(_trackPadding),
+        width: _trackWidth,
+        height: _trackHeight,
+        decoration: BoxDecoration(
+          color: const Color.fromRGBO(235, 236, 237, 1),
+          borderRadius: BorderRadius.circular(_trackRadius),
+        ),
+        child: AnimatedBuilder(
+          animation: Listenable.merge([position, reaction]),
+          builder: (context, child) {
+            final currentThumbExtension = _thumbExtension * reaction.value;
+            final currentThumbWidth = _thumbWidth + currentThumbExtension;
+
+            return Stack(
+              children: [
+                Positioned(
+                  left: lerpDouble(
+                    0,
+                    _trackInnerWidth - currentThumbWidth,
+                    position.value,
+                  ),
+                  child: Container(
+                    width: currentThumbWidth,
+                    height: _thumbHeight,
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(_thumbRadius),
+                    ),
+                  ),
+                ),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Center(
+                        child: Text(
+                          "${ReviewType.consulting}",
+                          style: TextStyle(
+                            fontWeight: widget.value == ReviewType.consulting
+                                ? FontWeight.bold
+                                : FontWeight.normal,
+                            color: Color.lerp(
+                              Colors.black,
+                              Colors.blue,
+                              (1 - position.value) * (1 - reaction.value),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: Center(
+                        child: Text(
+                          "${ReviewType.matching}",
+                          style: TextStyle(
+                            fontWeight: widget.value == ReviewType.matching
+                                ? FontWeight.bold
+                                : FontWeight.normal,
+                            color: Color.lerp(
+                              Colors.black,
+                              Colors.blue,
+                              position.value * (1 - reaction.value),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### PR 요약
- 리뷰 타입을 전환할 수 있는 스위치 추가

### 변경 사항

### 참고 사항
- API 통신을 위한 클래스가 아닌 클라이언트 내부 로직을 위한 클래스 또는 enum은 `lib/domains/`가 아닌 `lib/models/`로 따로 구분함. 추후에 `domains` 또는 `models`로 통합하여 관리하는 것이 더 깔끔할지 고민해 볼 것!