### PR TITLE
Feat: implement add and remove wishlist

### DIFF
--- a/lib/providers/wishlist_provider.dart
+++ b/lib/providers/wishlist_provider.dart
@@ -13,8 +13,14 @@ class Wishlist extends _$Wishlist {
   }
   Future<void> addToWishList(int portfolioId) async {
     await wishlistClient.add(portfolioId);
+    final updatedList = await wishlistClient.getAll();
+    state = AsyncValue.data(updatedList);
   }
   Future<void> removeFromWishList(int portfolioId) async {
     await wishlistClient.delete(portfolioId);
+    update((data) => data.where((element) => element.id != portfolioId).toList());
+  }
+  bool isFavorite(int portfolioId) {
+    return state.value?.any((element) => element.id == portfolioId) ?? false;
   }
 }

--- a/lib/providers/wishlist_provider.dart
+++ b/lib/providers/wishlist_provider.dart
@@ -5,6 +5,16 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'wishlist_provider.g.dart';
 
 @riverpod
-Future<List<PortfolioOverview>> wishlist(WishlistRef ref) {
-  return wishlistClient.getAll();
+class Wishlist extends _$Wishlist {
+
+  @override
+  Future<List<PortfolioOverview>> build() async {
+    return wishlistClient.getAll();
+  }
+  Future<void> addToWishList(int portfolioId) async {
+    await wishlistClient.add(portfolioId);
+  }
+  Future<void> removeFromWishList(int portfolioId) async {
+    await wishlistClient.delete(portfolioId);
+  }
 }

--- a/lib/utils/hooks.dart
+++ b/lib/utils/hooks.dart
@@ -2,7 +2,10 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 (bool, void Function()) useToggle([bool initialState = false]) {
   final state = useState(initialState);
-  final toggle = useCallback(() => state.value = !state.value);
+  final toggle = useCallback(() {
+    state.value = !state.value;
+
+  });
   return (state.value, toggle);
 }
 

--- a/lib/widgets/details_sliver_app_bar.dart
+++ b/lib/widgets/details_sliver_app_bar.dart
@@ -139,8 +139,8 @@ class _DetailsSliverAppBarState extends State<DetailsSliverAppBar> {
 
     final title = Text("${widget.portfolio.name} 웨딩플래너");
 
-    const actions = [
-      FavoriteToggleButton(initialFavorite: false),
+    final actions = [
+      FavoriteToggleButton(portfolioId: widget.portfolio.id, initialFavorite: false),
       SizedBox(width: 8),
     ];
 

--- a/lib/widgets/favorite_toggle_button.dart
+++ b/lib/widgets/favorite_toggle_button.dart
@@ -2,23 +2,37 @@ import 'package:dears/utils/hooks.dart';
 import 'package:dears/utils/icons.dart';
 import 'package:dears/utils/theme.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:logger/logger.dart';
 
-class FavoriteToggleButton extends HookWidget {
+import '../providers/wishlist_provider.dart';
+
+class FavoriteToggleButton extends HookConsumerWidget {
   final bool initialFavorite;
-
+  final int portfolioId;
   const FavoriteToggleButton({
     super.key,
     required this.initialFavorite,
+    required this.portfolioId,
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final (isFavorite, toggleFavorite) = useToggle(initialFavorite);
+    final wishlist = ref.read(wishlistProvider.notifier);
+
+    Future<void> handleToggle() async {
+      if (isFavorite) {
+        await wishlist.removeFromWishList(portfolioId);
+      } else {
+        await wishlist.addToWishList(portfolioId);
+      }
+      toggleFavorite();
+    }
 
     return IconButton(
       padding: const EdgeInsets.all(10),
-      onPressed: toggleFavorite,
+      onPressed: handleToggle,
       isSelected: isFavorite,
       selectedIcon: const Icon(DearsIcons.favorite, color: red),
       icon: const Icon(DearsIcons.favorite_outline),

--- a/lib/widgets/favorite_toggle_button.dart
+++ b/lib/widgets/favorite_toggle_button.dart
@@ -3,8 +3,6 @@ import 'package:dears/utils/icons.dart';
 import 'package:dears/utils/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:logger/logger.dart';
-
 import '../providers/wishlist_provider.dart';
 
 class FavoriteToggleButton extends HookConsumerWidget {
@@ -18,14 +16,15 @@ class FavoriteToggleButton extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final (isFavorite, toggleFavorite) = useToggle(initialFavorite);
-    final wishlist = ref.read(wishlistProvider.notifier);
+    final wishlist = ref.watch(wishlistProvider);
+    final (_, toggleFavorite) = useToggle(ref.read(wishlistProvider.notifier).isFavorite(portfolioId));
+    final isFavorite = wishlist.value?.any((element) => element.id == portfolioId) ?? false;
 
     Future<void> handleToggle() async {
       if (isFavorite) {
-        await wishlist.removeFromWishList(portfolioId);
+        await ref.read(wishlistProvider.notifier).removeFromWishList(portfolioId);
       } else {
-        await wishlist.addToWishList(portfolioId);
+        await ref.read(wishlistProvider.notifier).addToWishList(portfolioId);
       }
       toggleFavorite();
     }

--- a/lib/widgets/home_top_viewed_list_tile.dart
+++ b/lib/widgets/home_top_viewed_list_tile.dart
@@ -61,7 +61,7 @@ class HomeTopViewedListTile extends StatelessWidget {
               ],
             ),
             const Spacer(),
-            const FavoriteToggleButton(initialFavorite: false),
+            FavoriteToggleButton(portfolioId: portfolio.id, initialFavorite: false),
           ],
         ),
       ),

--- a/lib/widgets/portfolio_list_tile.dart
+++ b/lib/widgets/portfolio_list_tile.dart
@@ -86,7 +86,7 @@ class PortfolioListTile extends StatelessWidget {
               ],
             ),
             const Spacer(),
-            const FavoriteToggleButton(initialFavorite: true),
+            FavoriteToggleButton(portfolioId: portfolio.id, initialFavorite: true),
           ],
         ),
       ),


### PR DESCRIPTION
### PR 요약
wishlist 추가 및 삭제 기능 구현

### 변경 사항
wishlist provider 수정
FavoriteToggleButton 파라미터 추가
FavoriteToggleButton HookWidget -> HookConsumerWidget으로 수정

### 참고 사항
wishlist_provider 구현 과정에서 wishlist 추가 http 요청 후 상태를 수정하는 과정에서 현재는 http로 다시 전체 위시리스트를 받아오는 식으로 구현했으나 클라이언트 내에서 추가하는 식으로 구현하는 것이 적절할지 고민이네요. 
만약 그렇다면 int portfolioId를 파라미터로 받아오는 것이 아닌 PortfolioOverview 객체를 받아와야하는데 몇몇 페이지에서는 PortfolioOverview가 아닌 Portfolio 객체로부터 버튼을 만드는 곳이 있어서 [ex) DetailsSliverAppBar] 고민이 됩니다...

