### PR TITLE
feat: refine chat page

### DIFF
--- a/lib/models/member_role.dart
+++ b/lib/models/member_role.dart
@@ -15,7 +15,7 @@ enum MemberRole {
     };
   }
 
-  String get stompPrefix {
+  String get apiPrefix {
     return switch (this) {
       customer => "customer",
       weddingPlanner => "weddingplanner"

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -79,21 +79,24 @@ class ChatPage extends ConsumerWidget {
           const SizedBox(width: 8),
         ],
       ),
-      body: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        color: blue50,
-        child: Align(
-          alignment: Alignment.topCenter,
-          child: ListView(
-            // Initially scroll to the bottom
-            reverse: true,
-            physics: const ClampingScrollPhysics(),
-            shrinkWrap: true,
-            padding: EdgeInsets.zero,
-            children: [
-              ...bubbles,
-              const SizedBox(height: 10),
-            ].reversed.toList(),
+      body: GestureDetector(
+        onTap: () => FocusScope.of(context).unfocus(),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          color: blue50,
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: ListView(
+              // Initially scroll to the bottom
+              reverse: true,
+              physics: const ClampingScrollPhysics(),
+              shrinkWrap: true,
+              padding: EdgeInsets.zero,
+              children: [
+                ...bubbles,
+                const SizedBox(height: 10),
+              ].reversed.toList(),
+            ),
           ),
         ),
       ),

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -59,15 +59,10 @@ class ChatPage extends ConsumerWidget {
             createdAt = null;
           }
 
-          final isMe = item.isMe;
-          final isFirst = item.isMe != prev?.isMe;
-          final profileImageUrl =
-              !isMe && isFirst ? chatroom.othersProfileImageUrl : null;
-
           yield ChatBubble(
-            isMe: isMe,
-            isFirst: isFirst,
-            profileImageUrl: profileImageUrl,
+            chatroomId: chatroomId,
+            isMe: item.isMe,
+            isFirst: item.isMe != prev?.isMe,
             message: item.message,
             createdAt: createdAt,
           );

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -87,13 +87,19 @@ class ChatPage extends ConsumerWidget {
       body: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16),
         color: blue50,
-        child: ListView(
-          physics: const ClampingScrollPhysics(),
-          padding: EdgeInsets.zero,
-          children: [
-            ...bubbles,
-            const SizedBox(height: 10),
-          ],
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: ListView(
+            // Initially scroll to the bottom
+            reverse: true,
+            physics: const ClampingScrollPhysics(),
+            shrinkWrap: true,
+            padding: EdgeInsets.zero,
+            children: [
+              ...bubbles,
+              const SizedBox(height: 10),
+            ].reversed.toList(),
+          ),
         ),
       ),
       bottomNavigationBar: Padding(

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -87,13 +87,12 @@ class ChatPage extends ConsumerWidget {
       body: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16),
         color: blue50,
-        child: CustomScrollView(
+        child: ListView(
           physics: const ClampingScrollPhysics(),
-          slivers: [
-            ...bubbles.map((e) => SliverToBoxAdapter(child: e)),
-            const SliverToBoxAdapter(
-              child: SizedBox(height: 10),
-            ),
+          padding: EdgeInsets.zero,
+          children: [
+            ...bubbles,
+            const SizedBox(height: 10),
           ],
         ),
       ),

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -1,7 +1,6 @@
 import 'package:dears/providers/chatroom_provider.dart';
 import 'package:dears/providers/message_list_provider.dart';
 import 'package:dears/utils/formats.dart';
-import 'package:dears/utils/icons.dart';
 import 'package:dears/utils/theme.dart';
 import 'package:dears/utils/utils.dart';
 import 'package:dears/widgets/chat_bubble.dart';
@@ -76,10 +75,6 @@ class ChatPage extends ConsumerWidget {
         centerTitle: true,
         title: Text("${chatroom.othersName} 웨딩플래너"),
         actions: [
-          const Padding(
-            padding: EdgeInsets.all(10),
-            child: Icon(DearsIcons.more_vert),
-          ),
           FavoriteToggleButton(chatroom.portfolioId),
           const SizedBox(width: 8),
         ],

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -89,26 +89,25 @@ class ChatPage extends ConsumerWidget {
           const SizedBox(width: 8),
         ],
       ),
-      body: Column(
-        children: [
-          Expanded(
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              color: blue50,
-              child: CustomScrollView(
-                physics: const ClampingScrollPhysics(),
-                slivers: [
-                  ...bubbles.map((e) => SliverToBoxAdapter(child: e)),
-                  const SliverToBoxAdapter(
-                    child: SizedBox(height: 10),
-                  ),
-                ],
-              ),
+      body: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        color: blue50,
+        child: CustomScrollView(
+          physics: const ClampingScrollPhysics(),
+          slivers: [
+            ...bubbles.map((e) => SliverToBoxAdapter(child: e)),
+            const SliverToBoxAdapter(
+              child: SizedBox(height: 10),
             ),
-          ),
-          ChatTextField(chatroomId: chatroomId),
-          SizedBox(height: MediaQuery.of(context).padding.bottom),
-        ],
+          ],
+        ),
+      ),
+      bottomNavigationBar: Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom +
+              MediaQuery.of(context).padding.bottom,
+        ),
+        child: ChatTextField(chatroomId: chatroomId),
       ),
     );
   }

--- a/lib/pages/chat_redirect_page.dart
+++ b/lib/pages/chat_redirect_page.dart
@@ -1,5 +1,6 @@
 import 'package:dears/providers/chat_list_provider.dart';
 import 'package:dears/providers/chatroom_client_provider.dart';
+import 'package:dears/providers/stomp_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -38,7 +39,7 @@ class _ChatRedirectPageState extends ConsumerState<ChatRedirectPage> {
 
     final chatroomClient = await ref.read(chatroomClientProvider.future);
     final chatroom = await chatroomClient.createOrEnter(widget.portfolioId);
-    ref.invalidate(chatListProvider);
+    await ref.read(stompProvider.notifier).subscribe(chatroom.id);
 
     if (mounted) {
       context.replace("/chats/${chatroom.id}");

--- a/lib/providers/access_token_provider.dart
+++ b/lib/providers/access_token_provider.dart
@@ -5,11 +5,11 @@ part 'access_token_provider.g.dart';
 
 const String _key = "access_token";
 
-@Riverpod(keepAlive: true)
+@riverpod
 class AccessToken extends _$AccessToken {
   @override
   Future<String?> build() async {
-    final storage = ref.read(storageProvider);
+    final storage = ref.watch(storageProvider);
     return storage.read(key: _key);
   }
 

--- a/lib/providers/chat_list_provider.dart
+++ b/lib/providers/chat_list_provider.dart
@@ -14,29 +14,28 @@ class ChatList extends _$ChatList {
     return chatroomClient.getAll();
   }
 
-  void add(int chatroomId, Message message) {
-    update(
-      (data) {
-        final i = data.indexWhere((e) => e.id == chatroomId);
-        if (i == -1) {
-          return data;
-        }
+  Future<void> add(int chatroomId, Message message) async {
+    state = await AsyncValue.guard(() async {
+      final data = await future;
 
-        final overview = data[i];
-        data.removeAt(i);
+      final i = data.indexWhere((e) => e.id == chatroomId);
+      if (i == -1) {
+        return data;
+      }
 
-        final unreadCount = ref.exists(messageListProvider(chatroomId))
-            ? 0
-            : overview.unreadMessageCount + 1;
+      final overview = data[i];
+      data.removeAt(i);
 
-        final newOverview = overview.copyWith(
-          lastMessage: message.message,
-          lastMessageCreatedAt: message.createdAt,
-          unreadMessageCount: unreadCount,
-        );
-        return [newOverview, ...data];
-      },
-      onError: (err, stackTrace) => [],
-    );
+      final unreadCount = ref.exists(messageListProvider(chatroomId))
+          ? 0
+          : overview.unreadMessageCount + 1;
+
+      final newOverview = overview.copyWith(
+        lastMessage: message.message,
+        lastMessageCreatedAt: message.createdAt,
+        unreadMessageCount: unreadCount,
+      );
+      return [newOverview, ...data];
+    });
   }
 }

--- a/lib/providers/chat_list_provider.dart
+++ b/lib/providers/chat_list_provider.dart
@@ -7,11 +7,11 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'chat_list_provider.g.dart';
 
-@Riverpod(keepAlive: true)
+@riverpod
 class ChatList extends _$ChatList {
   @override
   Future<List<ChatroomOverview>> build() async {
-    final chatroomClient = await ref.read(chatroomClientProvider.future);
+    final chatroomClient = await ref.watch(chatroomClientProvider.future);
     final list = await chatroomClient.getAll();
 
     final stomp = ref.read(stompProvider.notifier);

--- a/lib/providers/chat_list_provider.dart
+++ b/lib/providers/chat_list_provider.dart
@@ -2,7 +2,6 @@ import 'package:dears/models/chatroom_overview.dart';
 import 'package:dears/models/message.dart';
 import 'package:dears/providers/chatroom_client_provider.dart';
 import 'package:dears/providers/message_list_provider.dart';
-import 'package:dears/providers/stomp_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'chat_list_provider.g.dart';
@@ -12,15 +11,7 @@ class ChatList extends _$ChatList {
   @override
   Future<List<ChatroomOverview>> build() async {
     final chatroomClient = await ref.watch(chatroomClientProvider.future);
-    final list = await chatroomClient.getAll();
-
-    final stomp = ref.read(stompProvider.notifier);
-    for (final chatroom in list) {
-      final unsubscribeFn = await stomp.subscribe(chatroom.id);
-      ref.onDispose(() => unsubscribeFn?.call());
-    }
-
-    return list;
+    return chatroomClient.getAll();
   }
 
   void add(int chatroomId, Message message) {

--- a/lib/providers/is_signed_in_provider.dart
+++ b/lib/providers/is_signed_in_provider.dart
@@ -4,7 +4,8 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'is_signed_in_provider.g.dart';
 
 @riverpod
-Future<bool> isSignedIn(IsSignedInRef ref) async {
-  final token = await ref.watch(accessTokenProvider.future);
-  return token != null;
+Future<bool> isSignedIn(IsSignedInRef ref) {
+  return ref.watch(
+    accessTokenProvider.selectAsync((data) => data != null),
+  );
 }

--- a/lib/providers/is_signed_in_provider.dart
+++ b/lib/providers/is_signed_in_provider.dart
@@ -3,7 +3,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'is_signed_in_provider.g.dart';
 
-@Riverpod(keepAlive: true)
+@riverpod
 Future<bool> isSignedIn(IsSignedInRef ref) async {
   final token = await ref.watch(accessTokenProvider.future);
   return token != null;

--- a/lib/providers/is_wish_listed_provider.dart
+++ b/lib/providers/is_wish_listed_provider.dart
@@ -4,7 +4,8 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'is_wish_listed_provider.g.dart';
 
 @riverpod
-Future<bool> isWishListed(IsWishListedRef ref, int portfolioId) async {
-  final wishList = await ref.watch(wishListIdsProvider.future);
-  return wishList.contains(portfolioId);
+Future<bool> isWishListed(IsWishListedRef ref, int portfolioId) {
+  return ref.watch(
+    wishListIdsProvider.selectAsync((data) => data.contains(portfolioId)),
+  );
 }

--- a/lib/providers/message_list_provider.dart
+++ b/lib/providers/message_list_provider.dart
@@ -29,10 +29,10 @@ class MessageList extends _$MessageList {
     }).toList();
   }
 
-  void add(Message message) {
-    update(
-      (data) => [...data, message],
-      onError: (err, stackTrace) => [],
-    );
+  Future<void> add(Message message) async {
+    state = await AsyncValue.guard(() async {
+      final data = await future;
+      return [...data, message];
+    });
   }
 }

--- a/lib/providers/message_list_provider.dart
+++ b/lib/providers/message_list_provider.dart
@@ -1,6 +1,5 @@
 import 'package:dears/models/message.dart';
 import 'package:dears/providers/chatroom_client_provider.dart';
-import 'package:dears/providers/stomp_provider.dart';
 import 'package:dears/providers/user_info_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -11,13 +10,14 @@ class MessageList extends _$MessageList {
   @override
   Future<List<Message>> build(int chatroomId) async {
     final chatroomClient = await ref.watch(chatroomClientProvider.future);
+
     final chatroom = await chatroomClient.enter(chatroomId);
+    // TODO: do not send leave message until server supports it
+    // ref.onDispose(() {
+    //   ref.read(stompProvider.notifier).leave(chatroomId);
+    // });
+
     final chats = chatroom.chats;
-
-    ref.onDispose(() {
-      ref.read(stompProvider.notifier).leave(chatroomId);
-    });
-
     final role = (await ref.read(userInfoProvider.future)).role;
 
     return chats.map((e) {

--- a/lib/providers/recent_search_words_provider.dart
+++ b/lib/providers/recent_search_words_provider.dart
@@ -25,31 +25,27 @@ class RecentSearchWords extends _$RecentSearchWords {
     state.whenOrNull(data: (data) => prefs.setStringList(_key, data).ignore());
   }
 
-  void add(String value) {
-    update(
-      (data) {
-        data.remove(value);
-        if (data.length >= _capacity) {
-          data.removeLast();
-        }
+  Future<void> add(String value) async {
+    state = await AsyncValue.guard(() async {
+      final data = await future;
 
-        return [value, ...data];
-      },
-      onError: (err, stackTrace) => [value],
-    );
+      data.remove(value);
+      if (data.length >= _capacity) {
+        data.removeLast();
+      }
+
+      return [value, ...data];
+    });
   }
 
-  void removeAt(int index) {
-    update(
-      (data) => [...data..removeAt(index)],
-      onError: (err, stackTrace) => [],
-    );
+  Future<void> removeAt(int index) async {
+    state = await AsyncValue.guard(() async {
+      final data = await future;
+      return [...data..removeAt(index)];
+    });
   }
 
   void clear() {
-    update(
-      (data) => [],
-      onError: (err, stackTrace) => [],
-    );
+    state = const AsyncValue.data([]);
   }
 }

--- a/lib/providers/stomp_provider.dart
+++ b/lib/providers/stomp_provider.dart
@@ -135,7 +135,7 @@ class Stomp extends _$Stomp {
     );
 
     client.send(
-      destination: "/pub/${role.stompPrefix}/send",
+      destination: "/pub/${role.apiPrefix}/send",
       body: jsonEncode(stompMessage),
     );
   }
@@ -156,7 +156,7 @@ class Stomp extends _$Stomp {
     );
 
     client.send(
-      destination: "/pub/${role.stompPrefix}/send",
+      destination: "/pub/${role.apiPrefix}/send",
       body: jsonEncode(stompMessage),
     );
   }

--- a/lib/providers/stomp_provider.dart
+++ b/lib/providers/stomp_provider.dart
@@ -3,9 +3,7 @@ import 'dart:convert';
 import 'package:dears/models/message.dart';
 import 'package:dears/models/message_type.dart';
 import 'package:dears/models/stomp_message.dart';
-import 'package:dears/providers/access_token_provider.dart';
 import 'package:dears/providers/chat_list_provider.dart';
-import 'package:dears/providers/is_signed_in_provider.dart';
 import 'package:dears/providers/message_list_provider.dart';
 import 'package:dears/providers/user_info_provider.dart';
 import 'package:dears/utils/env.dart';
@@ -19,12 +17,9 @@ part 'stomp_provider.g.dart';
 class Stomp extends _$Stomp {
   @override
   Future<StompClient?> build() async {
-    final isSignedIn = await ref.watch(isSignedInProvider.future);
-    if (!isSignedIn) {
-      return null;
-    }
-
-    final uuid = await ref.read(accessTokenProvider.future);
+    final uuid = await ref.watch(
+      userInfoProvider.selectAsync((data) => data.uuid),
+    );
     if (uuid == null) {
       return null;
     }
@@ -43,20 +38,23 @@ class Stomp extends _$Stomp {
     return client;
   }
 
-  void _onConnect(StompFrame frame) {
-    ref.read(chatListProvider);
+  Future<void> _onConnect(StompFrame frame) async {
+    final chatList = await ref.read(chatListProvider.future);
+    for (final chatroom in chatList) {
+      subscribe(chatroom.id);
+    }
     _listenNew();
   }
 
-  Future<StompUnsubscribe?> subscribe(int chatroomId) async {
+  Future<void> subscribe(int chatroomId) async {
     final client = await future;
     if (client == null) {
-      return null;
+      return;
     }
 
     final role = (await ref.read(userInfoProvider.future)).role;
 
-    return client.subscribe(
+    final unsubscribeFn = client.subscribe(
       destination: "/sub/$chatroomId",
       callback: (frame) {
         final body = frame.body;
@@ -79,9 +77,13 @@ class Stomp extends _$Stomp {
         if (ref.exists(messageListProvider(chatroomId))) {
           ref.read(messageListProvider(chatroomId).notifier).add(message);
         }
-        ref.read(chatListProvider.notifier).add(chatroomId, message);
+        if (ref.exists(chatListProvider)) {
+          ref.read(chatListProvider.notifier).add(chatroomId, message);
+        }
       },
     );
+
+    ref.onDispose(unsubscribeFn);
   }
 
   Future<void> _listenNew() async {
@@ -95,7 +97,7 @@ class Stomp extends _$Stomp {
       return;
     }
 
-    client.subscribe(
+    final unsubscribeFn = client.subscribe(
       destination: "/sub/$uuid",
       callback: (frame) {
         final body = frame.body;
@@ -109,9 +111,12 @@ class Stomp extends _$Stomp {
           return;
         }
 
-        ref.invalidate(chatListProvider);
+        subscribe(stompMessage.chatroomId);
+        // Do not update `chatListProvider` not to let the user know
       },
     );
+
+    ref.onDispose(unsubscribeFn);
   }
 
   Future<void> send(int chatroomId, String content) async {

--- a/lib/providers/stomp_provider.dart
+++ b/lib/providers/stomp_provider.dart
@@ -15,7 +15,7 @@ import 'package:stomp_dart_client/stomp_dart_client.dart';
 
 part 'stomp_provider.g.dart';
 
-@Riverpod(keepAlive: true)
+@riverpod
 class Stomp extends _$Stomp {
   @override
   Future<StompClient?> build() async {

--- a/lib/providers/user_info_provider.dart
+++ b/lib/providers/user_info_provider.dart
@@ -33,7 +33,6 @@ class UserInfo extends _$UserInfo {
   }
 
   Future<void> toggle() async {
-    state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final data = await future;
       final user = User(role: data.role.toggled);
@@ -42,11 +41,11 @@ class UserInfo extends _$UserInfo {
   }
 
   Future<void> signUp() async {
-    state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
+      final data = await future;
+
       final authClient = await ref.read(authClientProvider.future);
 
-      final data = await future;
       final member = await authClient.createMember(
         data: MemberCreateBody(role: data.role),
       );

--- a/lib/providers/wish_list_ids_provider.dart
+++ b/lib/providers/wish_list_ids_provider.dart
@@ -13,10 +13,9 @@ class WishListIds extends _$WishListIds {
   }
 
   Future<void> toggle(int portfolioId) async {
-    final data = await future;
-
-    state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
+      final data = await future;
+
       final wishlistClient = await ref.read(wishlistClientProvider.future);
 
       final isWishListed = data.contains(portfolioId);

--- a/lib/utils/formats.dart
+++ b/lib/utils/formats.dart
@@ -38,6 +38,9 @@ final CustomFormatter<DateTime> recent = CustomFormatter((date) {
   final now = DateTime.now();
 
   final diff = now.difference(date);
+  if (diff.inMinutes == 0) {
+    return "방금";
+  }
   if (diff.inHours == 0) {
     return "${diff.inMinutes}분 전";
   }

--- a/lib/widgets/chat_bubble.dart
+++ b/lib/widgets/chat_bubble.dart
@@ -1,28 +1,35 @@
+import 'package:dears/providers/chatroom_provider.dart';
 import 'package:dears/utils/formats.dart';
 import 'package:dears/utils/icons.dart';
 import 'package:dears/utils/theme.dart';
 import 'package:dears/utils/utils.dart';
 import 'package:dears/widgets/cdn_image.dart';
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class ChatBubble extends StatelessWidget {
+class ChatBubble extends ConsumerWidget {
+  final int chatroomId;
   final bool isMe;
   final bool isFirst;
-  final String? profileImageUrl;
   final String message;
   final DateTime? createdAt;
 
   const ChatBubble({
     super.key,
+    required this.chatroomId,
     required this.isMe,
     required this.isFirst,
-    this.profileImageUrl,
     required this.message,
     this.createdAt,
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profileImageUrl = ref
+        .watch(chatroomProvider(chatroomId))
+        .valueOrNull
+        ?.othersProfileImageUrl;
+
     final padding = isFirst
         ? const EdgeInsets.only(top: 20)
         : const EdgeInsets.only(top: 6);

--- a/lib/widgets/chat_text_field.dart
+++ b/lib/widgets/chat_text_field.dart
@@ -31,20 +31,40 @@ class ChatTextField extends HookConsumerWidget {
       const [],
     );
 
+    final focusNode = useFocusNode();
+    final isFocused = useState(false);
+
+    useEffect(
+      () {
+        void listener() {
+          isFocused.value = focusNode.hasFocus;
+        }
+
+        focusNode.addListener(listener);
+        return () => focusNode.removeListener(listener);
+      },
+      const [],
+    );
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
-          const Padding(
-            padding: EdgeInsets.all(10),
-            child: Icon(DearsIcons.link),
+          IconButton(
+            padding: const EdgeInsets.all(10),
+            onPressed: () {},
+            icon: Icon(
+              isFocused.value ? DearsIcons.add : DearsIcons.link,
+              color: gray600,
+            ),
           ),
           Expanded(
             child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 2),
               child: TextField(
                 controller: controller,
+                focusNode: focusNode,
                 style: bodySmall,
                 decoration: const InputDecoration(
                   hintText: "메시지를 입력해주세요",

--- a/lib/widgets/chat_text_field.dart
+++ b/lib/widgets/chat_text_field.dart
@@ -80,7 +80,6 @@ class ChatTextField extends HookConsumerWidget {
                 ),
                 maxLines: 4,
                 minLines: 1,
-                onTapOutside: (event) => FocusScope.of(context).unfocus(),
                 scrollPhysics: const ClampingScrollPhysics(),
               ),
             ),


### PR DESCRIPTION
### PR 요약
- `ChatPage`
  - `ListView.reverse` 속성을 통해 해당 화면에 들어갔을 때 가장 최근 메시지를 바로 볼 수 있도록 스크롤을 가장 밑으로 내리게 함.
  - `Scaffold.body`를 `GestureDetector`로 감싸고 `onTap`을 `FocusNode.unfocus()`하도록 하여 텍스트 입력 중 화면을 터치해 키보드를 내릴 수 있도록 하고, 화면을 스크롤 하는 경우에는 내려가지 않도록 함.
- 기타 provider 최적화
  - `Riverpod.keepAlive` 속성을 해제함. (이미 root widget인 `MainApp`에서 `watch`하기 때문에 불필요함.)
  - `AsyncProvider`가 primitive 타입(i.e. `int`, `bool`)인 경우에 무조건 rebuild 되는 현상을 방지하기 위해 `selectAsync`로 최적화함.
  - `update()` 메소드 대신에 `state`를 직접 `set`하는 방식으로 변경함.

### 변경 사항

### 참고 사항
- `ListView.reverse` 속성을 적용하면 기대한 대로 동작하긴 하지만 다음과 같은 문제들로 인해 여러 속성 및 위젯을 추가함.
  1. `children`이 역순으로 표시되는 문제: `children.reversed.toList()`로 리스트를 역순으로 지정함.
  2. 화면을 스크롤할 수 있을 만큼 `children`이 충분하지 않을 때, 화면의 하단에 `ListView`가 위치하는 문제: `ListView.shrinkWrap`을 `true`로 설정하고 `ListView`를 `Align` 위젯으로 감싸 위치를 지정함.
