### PR TITLE
feat: role prefix prepending interceptor

### DIFF
--- a/lib/clients/chatroom_client.dart
+++ b/lib/clients/chatroom_client.dart
@@ -12,12 +12,12 @@ abstract class ChatroomClient {
   @POST("/shared/delete/{id}")
   Future<void> exit(@Path() int id);
 
-  @POST("/customer/{portfolioId}")
+  @POST("/{role}/{portfolioId}")
   Future<Chatroom> createOrEnter(@Path() int portfolioId);
 
-  @GET("/customer/all")
+  @GET("/{role}/all")
   Future<List<ChatroomOverview>> getAll();
 
-  @POST("/customer/enter/{id}")
+  @POST("/{role}/enter/{id}")
   Future<Chatroom> enter(@Path() int id);
 }

--- a/lib/clients/mypage_client.dart
+++ b/lib/clients/mypage_client.dart
@@ -9,10 +9,10 @@ part 'mypage_client.g.dart';
 abstract class MypageClient {
   factory MypageClient(Dio dio, {String baseUrl}) = _MypageClient;
 
-  @GET("/customer/me")
+  @GET("/{role}/me")
   Future<Profile> getProfile();
 
-  @POST("/customer/customerservice")
+  @POST("/{role}/customerservice")
   Future<void> submit({
     @Body() required InquiryRequestBody data,
   });

--- a/lib/clients/portfolio_client.dart
+++ b/lib/clients/portfolio_client.dart
@@ -30,15 +30,15 @@ abstract class PortfolioClient {
   @GET("/shared/top5")
   Future<List<PortfolioOverview>> getTopViewed();
 
-  @POST("/weddingplanner/create")
+  @POST("/{role}/create")
   Future<Portfolio> create({
     @Body() required Portfolio body,
   });
 
-  @POST("/weddingplanner/delete/{id}")
+  @POST("/{role}/delete/{id}")
   Future<void> delete(@Path() int id);
 
-  @POST("/weddingplanner/update/{id}")
+  @POST("/{role}/update/{id}")
   Future<Portfolio> update(
     @Path() int id, {
     @Body() required Portfolio body,

--- a/lib/clients/review_client.dart
+++ b/lib/clients/review_client.dart
@@ -19,18 +19,18 @@ abstract class ReviewClient {
   @GET("/shared/soft-deleted")
   Future<List<Review>> getAllSoftDeleted();
 
-  @POST("/customer/create")
+  @POST("/{role}/create")
   Future<ReviewCreateResponse> create({
     @Body() required ReviewCreateBody data,
   });
 
-  @POST("/customer/delete/{id}")
+  @POST("/{role}/delete/{id}")
   Future<void> delete(@Path() int id);
 
-  @GET("/customer/me")
+  @GET("/{role}/me")
   Future<List<Review>> getAllMine();
 
-  @POST("/customer/update/{id}")
+  @POST("/{role}/update/{id}")
   Future<Review> update(
     @Path() int id, {
     @Body() required Review data,

--- a/lib/clients/wishlist_client.dart
+++ b/lib/clients/wishlist_client.dart
@@ -8,15 +8,15 @@ part 'wishlist_client.g.dart';
 abstract class WishlistClient {
   factory WishlistClient(Dio dio, {String baseUrl}) = _WishlistClient;
 
-  @POST("/customer/delete/{portfolioId}")
+  @POST("/{role}/delete/{portfolioId}")
   Future<void> delete(@Path() int portfolioId);
 
-  @GET("/customer/me")
+  @GET("/{role}/me")
   Future<List<PortfolioOverview>> getAll({
     @Query("page") int? page,
     @Query("size") int? size,
   });
 
-  @POST("/customer/post/{portfolioId}")
+  @POST("/{role}/post/{portfolioId}")
   Future<void> add(@Path() int portfolioId);
 }

--- a/lib/providers/api_dio_provider.dart
+++ b/lib/providers/api_dio_provider.dart
@@ -1,4 +1,5 @@
 import 'package:dears/providers/auth_interceptor_provider.dart';
+import 'package:dears/providers/role_interceptor_provider.dart';
 import 'package:dears/utils/dio.dart';
 import 'package:dears/utils/env.dart';
 import 'package:dio/dio.dart';
@@ -14,6 +15,9 @@ Future<Dio> apiDio(ApiDioRef ref) async {
     // `Dio.options.baseUrl` should end with a trailing slash
     // and `RestApi.baseUrl` should not start with a leading slash.
     ..options.baseUrl = "$baseUrl/api/";
+
+  final roleInterceptor = await ref.watch(roleInterceptorProvider.future);
+  dio.interceptors.add(roleInterceptor);
 
   final authInterceptor = await ref.watch(authInterceptorProvider.future);
   dio.interceptors.add(authInterceptor);

--- a/lib/providers/role_interceptor_provider.dart
+++ b/lib/providers/role_interceptor_provider.dart
@@ -4,6 +4,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'role_interceptor_provider.g.dart';
 
+/// A provider that returns an interceptor that replaces the path with the role.
+/// It gets the role from the [UserInfo] and prepends the role to the path
+/// if the path starts with `/{role}`.
 @riverpod
 Future<Interceptor> roleInterceptor(RoleInterceptorRef ref) async {
   final role = await ref.watch(

--- a/lib/providers/role_interceptor_provider.dart
+++ b/lib/providers/role_interceptor_provider.dart
@@ -1,0 +1,22 @@
+import 'package:dears/providers/user_info_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'role_interceptor_provider.g.dart';
+
+@riverpod
+Future<Interceptor> roleInterceptor(RoleInterceptorRef ref) async {
+  final role = await ref.watch(
+    userInfoProvider.selectAsync((data) => data.role),
+  );
+
+  return InterceptorsWrapper(
+    onRequest: (options, handler) {
+      if (options.path.startsWith("/{role}")) {
+        options.path = options.path.replaceFirst("{role}", role.apiPrefix);
+      }
+
+      return handler.next(options);
+    },
+  );
+}


### PR DESCRIPTION
### PR 요약
- API prefix(`customer`, `weddingplanner`)를 현재 접속 중인 유저의 `role`에 따라 자동으로 설정되도록 수정함.

### 변경 사항

### 참고 사항
- Retrofit을 이용해 API를 구현할 때 role prefix가 있는 endpoint는 `/{role}`로 시작하도록 설정해야 함.