### PR TITLE
feat: use logger

### DIFF
--- a/lib/providers/stomp_provider.dart
+++ b/lib/providers/stomp_provider.dart
@@ -7,7 +7,7 @@ import 'package:dears/providers/chat_list_provider.dart';
 import 'package:dears/providers/message_list_provider.dart';
 import 'package:dears/providers/user_info_provider.dart';
 import 'package:dears/utils/env.dart';
-import 'package:flutter/foundation.dart';
+import 'package:dears/utils/logger.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:stomp_dart_client/stomp_dart_client.dart';
 
@@ -29,8 +29,8 @@ class Stomp extends _$Stomp {
         url: "$baseUrl/stomp/chat",
         stompConnectHeaders: {"Authorization": uuid},
         onConnect: _onConnect,
-        onWebSocketError: kDebugMode ? print : (_) {},
-        onDebugMessage: kDebugMode ? print : (_) {},
+        onWebSocketError: logger.e,
+        onDebugMessage: logger.d,
       ),
     )..activate();
     ref.onDispose(client.deactivate);

--- a/lib/utils/logger.dart
+++ b/lib/utils/logger.dart
@@ -1,0 +1,51 @@
+import 'dart:developer';
+
+import 'package:logger/logger.dart';
+
+final Logger logger = Logger(
+  printer: CustomLogPrinter(),
+  output: DeveloperConsoleOutput(),
+);
+
+class CustomLogPrinter extends LogPrinter {
+  static const levelPrefixes = {
+    Level.trace: "TRACE",
+    Level.debug: "DEBUG",
+    Level.info: "INFO",
+    Level.warning: "WARN",
+    Level.error: "ERROR",
+    Level.fatal: "FATAL",
+  };
+
+  static AnsiColor getLevelColor(Level level) {
+    return PrettyPrinter.defaultLevelColors[level] ?? const AnsiColor.none();
+  }
+
+  @override
+  List<String> log(LogEvent event) {
+    final time = DateTimeFormat.onlyTime(event.time);
+
+    final color = getLevelColor(event.level);
+    final label = (levelPrefixes[event.level] ?? "").padLeft(5);
+
+    final error = event.error;
+    final stackTrace = event.stackTrace ?? StackTrace.current;
+
+    return [
+      "$time ${color(label)} ${event.message}",
+      if (error != null) ...[
+        "Error: $error",
+        "$stackTrace",
+      ],
+    ];
+  }
+}
+
+class DeveloperConsoleOutput extends LogOutput {
+  @override
+  void output(OutputEvent event) {
+    final buffer = StringBuffer();
+    event.lines.forEach(buffer.writeln);
+    log(buffer.toString());
+  }
+}

--- a/lib/utils/logger.dart
+++ b/lib/utils/logger.dart
@@ -3,43 +3,15 @@ import 'dart:developer';
 import 'package:logger/logger.dart';
 
 final Logger logger = Logger(
-  printer: CustomLogPrinter(),
+  printer: PrefixPrinter(
+    PrettyPrinter(
+      errorMethodCount: null,
+      printEmojis: false,
+      dateTimeFormat: DateTimeFormat.onlyTime,
+    ),
+  ),
   output: DeveloperConsoleOutput(),
 );
-
-class CustomLogPrinter extends LogPrinter {
-  static const levelPrefixes = {
-    Level.trace: "TRACE",
-    Level.debug: "DEBUG",
-    Level.info: "INFO",
-    Level.warning: "WARN",
-    Level.error: "ERROR",
-    Level.fatal: "FATAL",
-  };
-
-  static AnsiColor getLevelColor(Level level) {
-    return PrettyPrinter.defaultLevelColors[level] ?? const AnsiColor.none();
-  }
-
-  @override
-  List<String> log(LogEvent event) {
-    final time = DateTimeFormat.onlyTime(event.time);
-
-    final color = getLevelColor(event.level);
-    final label = (levelPrefixes[event.level] ?? "").padLeft(5);
-
-    final error = event.error;
-    final stackTrace = event.stackTrace ?? StackTrace.current;
-
-    return [
-      "$time ${color(label)} ${event.message}",
-      if (error != null) ...[
-        "Error: $error",
-        "$stackTrace",
-      ],
-    ];
-  }
-}
 
 class DeveloperConsoleOutput extends LogOutput {
   @override

--- a/lib/utils/provider_observer.dart
+++ b/lib/utils/provider_observer.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:dears/utils/logger.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class MainObserver extends ProviderObserver {
@@ -11,10 +11,6 @@ class MainObserver extends ProviderObserver {
     StackTrace stackTrace,
     ProviderContainer container,
   ) {
-    if (kDebugMode) {
-      print(provider);
-      print(error);
-      print("\n$stackTrace");
-    }
+    logger.d(provider, error: error, stackTrace: stackTrace);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -688,6 +688,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  logger:
+    dependency: "direct main"
+    description:
+      name: logger
+      sha256: "697d067c60c20999686a0add96cf6aba723b3aa1f83ecf806a8097231529ec32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   image_picker: ^1.1.2
   intl: ^0.19.0
   json_annotation: ^4.9.0
+  logger: ^2.4.0
   pretty_dio_logger: ^1.4.0
   retrofit: ^4.1.0
   riverpod_annotation: ^2.3.5


### PR DESCRIPTION
### PR 요약
로거 패키지를 추가했습니다. 로거 스타일을 바꾸고 싶으면 언제든지 PR 올려주세요.

### 변경 사항

### 참고 사항
- iOS를 빌드해서 실행하는 경우 로그의 색상이 콘솔에 적용되지 않는 이슈가 있어, 로그 출력 부분에 `dart:developer`의 `log()` 함수를 사용했습니다.
- 로그 레벨을 명확히 알기 위해 `PrefixPrinter`를 적용했습니다.
- 로깅 위치를 알기 위해 `PrettyPrinter.methodCount`의 기본값을 사용했습니다.
- 현재 `dio`의 로그 인터셉터인 `pretty_dio_logger`가 타임스탬프를 지원하지 않아 로거와 연계하는 방안을 고려하고 있습니다.