### PR TITLE
feat: set log name to label

### DIFF
--- a/lib/utils/logger.dart
+++ b/lib/utils/logger.dart
@@ -3,12 +3,10 @@ import 'dart:developer';
 import 'package:logger/logger.dart';
 
 final Logger logger = Logger(
-  printer: PrefixPrinter(
-    PrettyPrinter(
-      errorMethodCount: null,
-      printEmojis: false,
-      dateTimeFormat: DateTimeFormat.onlyTime,
-    ),
+  printer: PrettyPrinter(
+    errorMethodCount: null,
+    printEmojis: false,
+    dateTimeFormat: DateTimeFormat.onlyTime,
   ),
   output: DeveloperConsoleOutput(),
 );
@@ -18,6 +16,19 @@ class DeveloperConsoleOutput extends LogOutput {
   void output(OutputEvent event) {
     final buffer = StringBuffer();
     event.lines.forEach(buffer.writeln);
-    log(buffer.toString());
+    log(buffer.toString(), name: event.level.label);
   }
+}
+
+extension on Level {
+  static final _labels = {
+    Level.trace: "TRACE",
+    Level.debug: "DEBUG",
+    Level.info: "INFO",
+    Level.warning: "WARN",
+    Level.error: "ERROR",
+    Level.fatal: "FATAL",
+  };
+
+  String get label => (_labels[this] ?? "").padLeft(5);
 }


### PR DESCRIPTION
### PR 요약
- 로그 레벨을 `PrefixPrinter` 대신 `log()` 함수의 `name` 속성으로 설정

### 변경 사항
```diff
- [log]   TRACE ┌────
+ [TRACE] ┌──────────
```

### 참고 사항
