### PR TITLE
fix: handle scope cancellation exception

### DIFF
--- a/lib/providers/auth_state_provider.dart
+++ b/lib/providers/auth_state_provider.dart
@@ -74,9 +74,19 @@ class GoogleOAuth2Provider extends OAuth2Provider {
         "https://www.googleapis.com/auth/userinfo.profile",
       ],
     );
-    final account = await settings.signIn();
-    final auth = await account?.authentication;
-    return auth?.accessToken;
+
+    try {
+      final account = await settings.signIn();
+      final auth = await account?.authentication;
+      return auth?.accessToken;
+    } on PlatformException catch (e) {
+      if (e.code == GoogleSignIn.kSignInFailedError) {
+        logger.d("failed to sign in with Google: $e");
+        return null;
+      }
+
+      rethrow;
+    }
   }
 
   @override

--- a/lib/providers/auth_state_provider.dart
+++ b/lib/providers/auth_state_provider.dart
@@ -24,7 +24,7 @@ class AuthState extends _$AuthState {
   Future<void> signIn(OAuth2Provider provider) async {
     final token = await provider.getToken();
     if (token == null) {
-      throw Exception("failed to get token");
+      throw const TokenIssuanceException();
     }
 
     final client = await ref.read(oauth2ClientProvider.future);
@@ -145,4 +145,11 @@ class KakaoOAuth2Provider extends OAuth2Provider {
     final data = KakaoOAuth2Body(kakaoAccessToken: token, role: role);
     return client.signInWithKakao(data: data);
   }
+}
+
+class TokenIssuanceException implements Exception {
+  const TokenIssuanceException();
+
+  @override
+  String toString() => "TokenIssuanceException: failed to issue token";
 }

--- a/lib/widgets/sign_in_button.dart
+++ b/lib/widgets/sign_in_button.dart
@@ -27,7 +27,7 @@ class SignInButton extends ConsumerWidget {
 
           if (!context.mounted) return;
           context.go("/");
-        } catch (e, s) {
+        } on TokenIssuanceException catch (e, s) {
           logger.d("failed to sign in", error: e, stackTrace: s);
         }
       },


### PR DESCRIPTION
### PR 요약
- 정보 제공 동의 거부 시에 발생하는 예외(`GoogleSignIn.kSignInFailedError`) 핸들링
- OAuth2.0 인증에 대한 로그아웃을 클라이언트에서 즉시 처리
  - 클라이언트(플러터 앱)에서 Google, kakao 등 각각의 sdk를 통해 발급한 토큰으로 서비스 서버(우리 백엔드)가 인증 및 토큰 발급을 마무리하면 클라이언트에서 sdk가 제공하는 로그아웃 메소드를 실행하도록 설정

### 변경 사항

### 참고 사항
fix #38 
