### PR TITLE
feat: recent-seen portfolios

### DIFF
--- a/lib/models/member_role.dart
+++ b/lib/models/member_role.dart
@@ -14,4 +14,12 @@ enum MemberRole {
       weddingPlanner => "weddingplanner"
     };
   }
+
+  @override
+  String toString() {
+    return switch (this) {
+      customer => "예비 신혼부부",
+      weddingPlanner => "웨딩플래너",
+    };
+  }
 }

--- a/lib/pages/chat_list_page.dart
+++ b/lib/pages/chat_list_page.dart
@@ -1,7 +1,7 @@
 import 'package:dears/providers/chat_list_provider.dart';
 import 'package:dears/widgets/chat_list_tile.dart';
 import 'package:dears/widgets/custom_app_bar.dart';
-import 'package:dears/widgets/list_status_widget.dart';
+import 'package:dears/widgets/status_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -12,7 +12,7 @@ class ChatListPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final chatList = ref.watch(chatListProvider);
 
-    const emptyWidget = EmptyListWidget(
+    const emptyWidget = EmptyWidget(
       title: "대화 중인 웨딩플래너가 없습니다",
       subtitle: "마음에 드는 웨딩플래너와 대화해보세요",
     );
@@ -23,20 +23,18 @@ class ChatListPage extends ConsumerWidget {
           return emptyWidget;
         }
 
-        return Expanded(
-          child: ListView.separated(
-            physics: const ClampingScrollPhysics(),
-            itemCount: data.length,
-            separatorBuilder: (context, index) => const SizedBox(height: 10),
-            itemBuilder: (context, index) {
-              final chat = data[index];
-              return ChatListTile(chat);
-            },
-          ),
+        return ListView.separated(
+          physics: const ClampingScrollPhysics(),
+          itemCount: data.length,
+          separatorBuilder: (context, index) => const SizedBox(height: 10),
+          itemBuilder: (context, index) {
+            final chat = data[index];
+            return ChatListTile(chat);
+          },
         );
       },
       error: (error, stackTrace) => emptyWidget,
-      loading: () => const LoadingListWidget(),
+      loading: () => const LoadingWidget(),
     );
 
     return Scaffold(
@@ -46,7 +44,9 @@ class ChatListPage extends ConsumerWidget {
       body: Column(
         children: [
           const SizedBox(height: 24),
-          child,
+          Expanded(
+            child: child,
+          ),
         ],
       ),
     );

--- a/lib/pages/favorite_page.dart
+++ b/lib/pages/favorite_page.dart
@@ -1,8 +1,8 @@
 import 'package:dears/providers/wishlist_provider.dart';
 import 'package:dears/utils/theme.dart';
 import 'package:dears/widgets/custom_app_bar.dart';
-import 'package:dears/widgets/list_status_widget.dart';
 import 'package:dears/widgets/portfolio_list_tile.dart';
+import 'package:dears/widgets/status_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -29,7 +29,7 @@ class _FavoritePageState extends ConsumerState<FavoritePage> {
     // Mark the `wishlist` as loading when the page is opened.
     final wishlist = ref.watch(wishlistProvider).unwrapPrevious();
 
-    const emptyWidget = EmptyListWidget(
+    const emptyWidget = EmptyWidget(
       title: "저장한 웨딩플래너가 없습니다",
       subtitle: "마음에 드는 웨딩플래너를 저장해보세요",
     );
@@ -40,22 +40,20 @@ class _FavoritePageState extends ConsumerState<FavoritePage> {
           return emptyWidget;
         }
 
-        return Expanded(
-          child: ListView.separated(
-            physics: const ClampingScrollPhysics(),
-            itemCount: data.length,
-            separatorBuilder: (context, index) {
-              return const Divider(height: 4, indent: 16, endIndent: 16);
-            },
-            itemBuilder: (context, index) {
-              final overview = data[index];
-              return PortfolioListTile(overview);
-            },
-          ),
+        return ListView.separated(
+          physics: const ClampingScrollPhysics(),
+          itemCount: data.length,
+          separatorBuilder: (context, index) {
+            return const Divider(height: 4, indent: 16, endIndent: 16);
+          },
+          itemBuilder: (context, index) {
+            final overview = data[index];
+            return PortfolioListTile(overview);
+          },
         );
       },
       error: (error, stackTrace) => emptyWidget,
-      loading: () => const LoadingListWidget(),
+      loading: () => const LoadingWidget(),
     );
 
     final count = wishlist.maybeWhen(
@@ -87,7 +85,9 @@ class _FavoritePageState extends ConsumerState<FavoritePage> {
             ),
           ),
           const SizedBox(height: 8),
-          child,
+          Expanded(
+            child: child,
+          ),
         ],
       ),
     );

--- a/lib/pages/personal_page.dart
+++ b/lib/pages/personal_page.dart
@@ -3,6 +3,7 @@ import 'package:dears/utils/theme.dart';
 import 'package:dears/widgets/custom_app_bar.dart';
 import 'package:dears/widgets/personal_list_tile.dart';
 import 'package:dears/widgets/personal_profile_list_tile.dart';
+import 'package:dears/widgets/recent_seen_portfolio_list.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -20,6 +21,19 @@ class PersonalPage extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const PersonalProfileListTile(),
+          const Divider(
+            height: 4,
+            thickness: 4,
+            color: gray100,
+          ),
+          const SizedBox(height: 24),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16),
+            child: Text("최근 본 포트폴리오", style: titleMedium),
+          ),
+          const SizedBox(height: 16),
+          const RecentSeenPortfolioList(),
+          const SizedBox(height: 30),
           const Divider(
             height: 4,
             thickness: 4,

--- a/lib/pages/personal_page.dart
+++ b/lib/pages/personal_page.dart
@@ -1,5 +1,4 @@
 import 'package:dears/providers/auth_state_provider.dart';
-import 'package:dears/utils/icons.dart';
 import 'package:dears/utils/theme.dart';
 import 'package:dears/widgets/custom_app_bar.dart';
 import 'package:dears/widgets/personal_list_tile.dart';
@@ -26,41 +25,23 @@ class PersonalPage extends ConsumerWidget {
             thickness: 4,
             color: gray100,
           ),
+          const SizedBox(height: 24),
           const Padding(
-            padding: EdgeInsets.only(left: 13, top: 16, bottom: 10),
-            child: Text(
-              "내 활동",
-              style: TextStyle(
-                color: gray600,
-                fontSize: 13,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
+            padding: EdgeInsets.symmetric(horizontal: 16),
+            child: Text("고객센터", style: titleMedium),
+          ),
+          const SizedBox(height: 16),
+          PersonalListTile(
+            title: "문의하기",
+            onTap: () => context.push("/inquiry"),
           ),
           PersonalListTile(
+            title: "서비스 이용약관",
             onTap: () {},
-            title: const Text("내가 쓴 리뷰"),
-            leading: const Icon(DearsIcons.chat),
-            trailing: const Icon(DearsIcons.caret_right),
-          ),
-          const Padding(
-            padding: EdgeInsets.only(left: 13, top: 20, bottom: 10),
-            child: Text(
-              "고객센터",
-              style: TextStyle(
-                color: gray600,
-                fontSize: 13,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
           ),
           PersonalListTile(
-            onTap: () {
-              context.push("/inquiry");
-            },
-            leading: const Icon(DearsIcons.chat),
-            title: const Text("문의하기"),
-            trailing: const Icon(DearsIcons.caret_right),
+            title: "개인정보 처리 방침",
+            onTap: () {},
           ),
           const Spacer(),
           TextButton(

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -2,8 +2,8 @@ import 'package:dears/providers/recent_search_words_provider.dart';
 import 'package:dears/utils/icons.dart';
 import 'package:dears/utils/theme.dart';
 import 'package:dears/widgets/custom_app_bar.dart';
-import 'package:dears/widgets/list_status_widget.dart';
 import 'package:dears/widgets/search_text_field.dart';
+import 'package:dears/widgets/status_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -15,7 +15,7 @@ class SearchPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final recentSearchWords = ref.watch(recentSearchWordsProvider);
 
-    const emptyWidget = EmptyListWidget(
+    const emptyWidget = EmptyWidget(
       title: "최근 검색어가 없습니다",
       subtitle: "웨딩 관련 키워드를 검색해보세요",
     );
@@ -26,34 +26,31 @@ class SearchPage extends ConsumerWidget {
           return emptyWidget;
         }
 
-        return Expanded(
-          child: Wrap(
-            spacing: 10,
-            runSpacing: 10,
-            children: List.generate(data.length, (index) {
-              final label = data[index];
-              return FilterChip(
-                onSelected: (value) => context.push("/search?q=$label"),
-                onDeleted: () => ref
-                    .read(recentSearchWordsProvider.notifier)
-                    .removeAt(index),
-                deleteIcon: const Icon(
-                  DearsIcons.close,
-                  size: 16,
-                  color: gray600,
-                ),
-                side: const BorderSide(color: gray100),
-                label: Text(
-                  label,
-                  style: const TextStyle(color: gray800),
-                ),
-              );
-            }),
-          ),
+        return Wrap(
+          spacing: 10,
+          runSpacing: 10,
+          children: List.generate(data.length, (index) {
+            final label = data[index];
+            return FilterChip(
+              onSelected: (value) => context.push("/search?q=$label"),
+              onDeleted: () =>
+                  ref.read(recentSearchWordsProvider.notifier).removeAt(index),
+              deleteIcon: const Icon(
+                DearsIcons.close,
+                size: 16,
+                color: gray600,
+              ),
+              side: const BorderSide(color: gray100),
+              label: Text(
+                label,
+                style: const TextStyle(color: gray800),
+              ),
+            );
+          }),
         );
       },
       error: (error, stackTrace) => emptyWidget,
-      loading: () => const LoadingListWidget(),
+      loading: () => const LoadingWidget(),
     );
 
     return Scaffold(
@@ -92,7 +89,9 @@ class SearchPage extends ConsumerWidget {
               ],
             ),
             const SizedBox(height: 16),
-            chips,
+            Expanded(
+              child: chips,
+            ),
           ],
         ),
       ),

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -90,8 +90,11 @@ class SearchPage extends ConsumerWidget {
             ),
             const SizedBox(height: 16),
             Expanded(
-              child: chips,
+              child: SingleChildScrollView(
+                child: chips,
+              ),
             ),
+            SizedBox(height: MediaQuery.of(context).padding.bottom),
           ],
         ),
       ),

--- a/lib/pages/search_result_page.dart
+++ b/lib/pages/search_result_page.dart
@@ -1,9 +1,9 @@
 import 'package:dears/providers/search_result_provider.dart';
 import 'package:dears/utils/theme.dart';
 import 'package:dears/widgets/custom_app_bar.dart';
-import 'package:dears/widgets/list_status_widget.dart';
 import 'package:dears/widgets/portfolio_list_tile.dart';
 import 'package:dears/widgets/search_text_field.dart';
+import 'package:dears/widgets/status_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -20,7 +20,7 @@ class SearchResultPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final searchResult = ref.watch(searchResultProvider(query));
 
-    const emptyWidget = EmptyListWidget(
+    const emptyWidget = EmptyWidget(
       title: "검색 결과가 없습니다",
       subtitle: "다른 검색어로 검색해보세요",
     );
@@ -36,22 +36,20 @@ class SearchResultPage extends ConsumerWidget {
           return emptyWidget;
         }
 
-        return Expanded(
-          child: ListView.separated(
-            physics: const ClampingScrollPhysics(),
-            itemCount: data.length,
-            separatorBuilder: (context, index) {
-              return const Divider(height: 4, indent: 16, endIndent: 16);
-            },
-            itemBuilder: (context, index) {
-              final overview = data[index];
-              return PortfolioListTile(overview);
-            },
-          ),
+        return ListView.separated(
+          physics: const ClampingScrollPhysics(),
+          itemCount: data.length,
+          separatorBuilder: (context, index) {
+            return const Divider(height: 4, indent: 16, endIndent: 16);
+          },
+          itemBuilder: (context, index) {
+            final overview = data[index];
+            return PortfolioListTile(overview);
+          },
         );
       },
       error: (error, stackTrace) => emptyWidget,
-      loading: () => const LoadingListWidget(),
+      loading: () => const LoadingWidget(),
     );
 
     return Scaffold(
@@ -85,7 +83,9 @@ class SearchResultPage extends ConsumerWidget {
             ),
           ),
           const SizedBox(height: 8),
-          result,
+          Expanded(
+            child: result,
+          ),
         ],
       ),
     );

--- a/lib/widgets/personal_list_tile.dart
+++ b/lib/widgets/personal_list_tile.dart
@@ -1,103 +1,32 @@
+import 'package:dears/utils/icons.dart';
 import 'package:dears/utils/theme.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter/widgets.dart';
 
-class PersonalListTile extends HookWidget {
+class PersonalListTile extends StatelessWidget {
+  final String title;
   final GestureTapCallback? onTap;
-  final EdgeInsetsGeometry padding;
-  final Widget? leading;
-  final double titleSpacing;
-  final Widget title;
-  final Widget? subtitle;
-  final Widget? trailing;
 
   const PersonalListTile({
     super.key,
-    this.onTap,
-    this.padding = const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-    this.leading,
-    this.titleSpacing = 12,
     required this.title,
-    this.subtitle,
-    this.trailing,
+    this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    final tapped = useState(false);
-
-    final leading = this.leading;
-
-    Widget? trailing = this.trailing;
-    if (trailing != null) {
-      trailing = IconTheme(
-        data: const IconThemeData(size: 18),
-        child: trailing,
-      );
-    }
-
-    Widget title = DefaultTextStyle(
-      style: const TextStyle(
-        color: gray800,
-        fontSize: 16,
-        fontWeight: FontWeight.w500,
-      ),
-      child: this.title,
-    );
-
-    final subtitle = this.subtitle;
-    if (subtitle != null) {
-      title = Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          title,
-          const SizedBox(height: 4),
-          DefaultTextStyle(
-            style: const TextStyle(
-              color: gray600,
-              fontSize: 13,
-              fontWeight: FontWeight.w500,
-            ),
-            child: subtitle,
-          ),
-        ],
-      );
-    }
-
-    final child = Container(
-      padding: padding,
-      color: !tapped.value
-          ? null
-          : CupertinoColors.systemGrey4.resolveFrom(context),
-      child: Row(
-        children: [
-          if (leading != null) ...[
-            leading,
-            SizedBox(width: titleSpacing),
-          ],
-          title,
-          if (trailing != null) ...[
-            const Spacer(),
-            trailing,
-          ],
-        ],
-      ),
-    );
-
-    final onTap = this.onTap;
-    if (onTap == null) {
-      return child;
-    }
-
     return GestureDetector(
-      onTapDown: (details) => tapped.value = true,
-      onTapCancel: () => tapped.value = false,
-      onTap: () {
-        onTap();
-        tapped.value = false;
-      },
+      onTap: onTap,
       behavior: HitTestBehavior.opaque,
-      child: child,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(title, style: bodyLarge),
+            const Icon(DearsIcons.caret_right, size: 18),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/widgets/personal_profile_list_tile.dart
+++ b/lib/widgets/personal_profile_list_tile.dart
@@ -1,8 +1,8 @@
 import 'package:dears/providers/profile_provider.dart';
+import 'package:dears/providers/role_provider.dart';
 import 'package:dears/utils/icons.dart';
 import 'package:dears/utils/theme.dart';
 import 'package:dears/widgets/cdn_image.dart';
-import 'package:dears/widgets/personal_list_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -11,6 +11,8 @@ class PersonalProfileListTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final role = ref.watch(roleProvider).value;
+
     final profile = ref.watch(profileProvider);
 
     final url = profile.whenOrNull(
@@ -22,17 +24,44 @@ class PersonalProfileListTile extends ConsumerWidget {
       orElse: () => "",
     );
 
-    return PersonalListTile(
+    return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
-      leading: CdnImage.circle(
-        url,
-        dimension: 72,
-        fallback: const Icon(DearsIcons.person, size: 36),
+      child: Row(
+        children: [
+          CdnImage.circle(
+            url,
+            dimension: 72,
+            fallback: const Icon(DearsIcons.person, size: 36),
+          ),
+          const SizedBox(width: 8),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                decoration: const ShapeDecoration(
+                  color: blue50,
+                  shape: StadiumBorder(),
+                ),
+                child: Text(
+                  "$role",
+                  style: const TextStyle(
+                    color: blue500,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    height: 16 / 12,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 6),
+              Padding(
+                padding: const EdgeInsets.only(left: 4),
+                child: Text(name, style: titleMedium),
+              ),
+            ],
+          ),
+        ],
       ),
-      titleSpacing: 8,
-      title: Text(name, style: titleMedium),
-      trailing: const Icon(DearsIcons.caret_right, size: 24),
-      //Icon(DearsIcons.pencil_simple, size: 24),
     );
   }
 }

--- a/lib/widgets/portfolio_list_tile.dart
+++ b/lib/widgets/portfolio_list_tile.dart
@@ -9,10 +9,12 @@ import 'package:go_router/go_router.dart';
 
 class PortfolioListTile extends StatelessWidget {
   final PortfolioOverview portfolio;
+  final bool compact;
 
   const PortfolioListTile(
     this.portfolio, {
     super.key,
+    this.compact = false,
   });
 
   @override
@@ -21,63 +23,71 @@ class PortfolioListTile extends StatelessWidget {
     final avgRating = rating.format(portfolio.avgRating);
     final minEstimate = number.format(portfolio.minEstimate);
 
+    final padding = compact
+        ? EdgeInsets.zero
+        : const EdgeInsets.symmetric(horizontal: 16, vertical: 8);
+
     return GestureDetector(
       onTap: () => context.push("/details/${portfolio.id}"),
       behavior: HitTestBehavior.opaque,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        height: 100,
-        child: Row(
-          children: [
-            CdnImage(
-              portfolio.profileImageUrl,
-              width: 84,
-              height: 84,
-              borderRadius: BorderRadius.circular(4),
-              fallback: const Icon(DearsIcons.person, size: 32),
-            ),
-            const SizedBox(width: 10),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const SizedBox(height: 4),
-                Row(
-                  children: [
-                    Text(
-                      portfolio.plannerName,
-                      style: titleSmall,
-                    ),
-                    const SizedBox(width: 4),
-                    Text(
-                      portfolio.organization,
-                      style: bodySmall.copyWith(color: gray600),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 4),
-                Row(
-                  children: [
-                    Text(
-                      "리뷰($reviewCount)",
-                      style: captionLarge.copyWith(color: gray600),
-                    ),
-                    const SizedBox(width: 2),
-                    const Icon(DearsIcons.star, size: 16, color: yellow),
-                    const SizedBox(width: 2),
-                    Text(
-                      avgRating,
-                      style: captionLarge.copyWith(color: gray800),
-                    ),
-                  ],
-                ),
+      child: Padding(
+        padding: padding,
+        child: SizedBox(
+          height: 84,
+          child: Row(
+            children: [
+              CdnImage(
+                portfolio.profileImageUrl,
+                width: 84,
+                height: 84,
+                borderRadius: BorderRadius.circular(4),
+                fallback: const Icon(DearsIcons.person, size: 32),
+              ),
+              const SizedBox(width: 10),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      Text(
+                        portfolio.plannerName,
+                        style: titleSmall,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        portfolio.organization,
+                        style: bodySmall.copyWith(color: gray600),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      Text(
+                        "리뷰($reviewCount)",
+                        style: captionLarge.copyWith(color: gray600),
+                      ),
+                      const SizedBox(width: 2),
+                      const Icon(DearsIcons.star, size: 16, color: yellow),
+                      const SizedBox(width: 2),
+                      Text(
+                        avgRating,
+                        style: captionLarge.copyWith(color: gray800),
+                      ),
+                    ],
+                  ),
+                  const Spacer(),
+                  Text("$minEstimate원~", style: titleSmall),
+                  const SizedBox(height: 4),
+                ],
+              ),
+              if (!compact) ...[
                 const Spacer(),
-                Text("$minEstimate원~", style: titleSmall),
-                const SizedBox(height: 4),
+                FavoriteToggleButton(portfolio.id),
               ],
-            ),
-            const Spacer(),
-            FavoriteToggleButton(portfolio.id),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/recent_seen_portfolio_list.dart
+++ b/lib/widgets/recent_seen_portfolio_list.dart
@@ -1,6 +1,6 @@
 import 'package:dears/providers/top_viewed_provider.dart';
-import 'package:dears/widgets/list_status_widget.dart';
 import 'package:dears/widgets/portfolio_list_tile.dart';
+import 'package:dears/widgets/status_widget.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -12,7 +12,7 @@ class RecentSeenPortfolioList extends ConsumerWidget {
     // TODO: replace provider to one of recent seen portfolios
     final recentSeen = ref.watch(topViewedProvider);
 
-    const emptyWidget = EmptyListWidget(
+    const emptyWidget = EmptyWidget(
       title: "최근 본 포트폴리오가 없습니다",
       subtitle: "마음에 드는 포트폴리오를 찾아보세요",
     );
@@ -36,7 +36,7 @@ class RecentSeenPortfolioList extends ConsumerWidget {
         );
       },
       error: (error, stackTrace) => emptyWidget,
-      loading: () => const LoadingListWidget(),
+      loading: () => const LoadingWidget(),
     );
 
     return SizedBox(

--- a/lib/widgets/recent_seen_portfolio_list.dart
+++ b/lib/widgets/recent_seen_portfolio_list.dart
@@ -1,0 +1,47 @@
+import 'package:dears/providers/top_viewed_provider.dart';
+import 'package:dears/widgets/list_status_widget.dart';
+import 'package:dears/widgets/portfolio_list_tile.dart';
+import 'package:flutter/widgets.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class RecentSeenPortfolioList extends ConsumerWidget {
+  const RecentSeenPortfolioList({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // TODO: replace provider to one of recent seen portfolios
+    final recentSeen = ref.watch(topViewedProvider);
+
+    const emptyWidget = EmptyListWidget(
+      title: "최근 본 포트폴리오가 없습니다",
+      subtitle: "마음에 드는 포트폴리오를 찾아보세요",
+    );
+
+    final child = recentSeen.when(
+      data: (data) {
+        if (data.isEmpty) {
+          return emptyWidget;
+        }
+
+        return ListView.separated(
+          scrollDirection: Axis.horizontal,
+          physics: const ClampingScrollPhysics(),
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          itemCount: data.length,
+          separatorBuilder: (context, index) => const SizedBox(width: 20),
+          itemBuilder: (context, index) {
+            final portfolio = data[index];
+            return PortfolioListTile(portfolio, compact: true);
+          },
+        );
+      },
+      error: (error, stackTrace) => emptyWidget,
+      loading: () => const LoadingListWidget(),
+    );
+
+    return SizedBox(
+      height: 84,
+      child: child,
+    );
+  }
+}

--- a/lib/widgets/status_widget.dart
+++ b/lib/widgets/status_widget.dart
@@ -1,11 +1,11 @@
 import 'package:dears/utils/theme.dart';
 import 'package:flutter/material.dart';
 
-class EmptyListWidget extends StatelessWidget {
+class EmptyWidget extends StatelessWidget {
   final String title;
   final String? subtitle;
 
-  const EmptyListWidget({
+  const EmptyWidget({
     super.key,
     required this.title,
     this.subtitle,
@@ -29,25 +29,21 @@ class EmptyListWidget extends StatelessWidget {
             ],
           );
 
-    return Expanded(
-      child: Align(
-        alignment: const Alignment(0, -0.5),
-        child: child,
-      ),
+    return Align(
+      alignment: const Alignment(0, -0.5),
+      child: child,
     );
   }
 }
 
-class LoadingListWidget extends StatelessWidget {
-  const LoadingListWidget({super.key});
+class LoadingWidget extends StatelessWidget {
+  const LoadingWidget({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Expanded(
-      child: Align(
-        alignment: Alignment(0, -0.5),
-        child: CircularProgressIndicator(),
-      ),
+    return const Align(
+      alignment: Alignment(0, -0.5),
+      child: CircularProgressIndicator(),
     );
   }
 }


### PR DESCRIPTION
### PR 요약
- `RecentSeenPortfolioList`: 최근 본 포트폴리오 목록 추가

### 변경 사항
- `PersonalPage` - 레이아웃 변경 및 버튼 추가
- `PersonalListTile` - 다른 버튼과의 통일성을 위함 `onTap` 시 색상 변경 효과 임시 제거
- `EmptyWidget`, `LoadingWidget` - 범용성을 위해 `Expanded` 위젯 제거

### 참고 사항
<img src="https://github.com/user-attachments/assets/a9943a98-7041-47ac-b301-31f422968404" width=375>