### PR TITLE
feat: token reissue flow

### DIFF
--- a/lib/clients/oauth2_client.dart
+++ b/lib/clients/oauth2_client.dart
@@ -26,5 +26,6 @@ abstract class OAuth2Client {
   });
 
   @POST("/shared/reissue")
+  @Extra({"type": "token_refresh"})
   Future<ReissueResponse> reissue(@Field() String refreshToken);
 }

--- a/lib/providers/access_token_provider.dart
+++ b/lib/providers/access_token_provider.dart
@@ -1,31 +1,15 @@
 import 'package:dears/providers/secure_storage_provider.dart';
+import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'access_token_provider.g.dart';
 
-const String _key = "access_token";
-
-@riverpod
-class AccessToken extends _$AccessToken {
+@Riverpod(keepAlive: true)
+class AccessToken extends _$AccessToken with SecureStorageProviderMixin {
+  @protected
   @override
-  Future<String?> build() async {
-    final storage = ref.watch(storageProvider);
-    return storage.read(key: _key);
-  }
+  final key = "access_token";
 
-  Future<String?> _save(String? value) async {
-    final storage = ref.read(storageProvider);
-    await storage.write(key: _key, value: value);
-    return value;
-  }
-
-  Future<void> setValue(String value) async {
-    state = const AsyncValue.loading();
-    state = await AsyncValue.guard(() => _save(value));
-  }
-
-  Future<void> clear() async {
-    state = const AsyncValue.loading();
-    state = await AsyncValue.guard(() => _save(null));
-  }
+  @override
+  Future<String?> build();
 }

--- a/lib/providers/api_dio_provider.dart
+++ b/lib/providers/api_dio_provider.dart
@@ -1,7 +1,7 @@
 import 'package:dears/providers/auth_interceptor_provider.dart';
 import 'package:dears/providers/role_interceptor_provider.dart';
-import 'package:dears/utils/dio.dart';
 import 'package:dears/utils/env.dart';
+import 'package:dears/utils/log_interceptor.dart';
 import 'package:dio/dio.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -22,7 +22,7 @@ Future<Dio> apiDio(ApiDioRef ref) async {
   final authInterceptor = ref.watch(authInterceptorProvider);
   dio.interceptors.add(authInterceptor);
 
-  dio.interceptors.add(logInterceptor);
+  dio.interceptors.add(const CustomLogInterceptor());
 
   return dio;
 }

--- a/lib/providers/api_dio_provider.dart
+++ b/lib/providers/api_dio_provider.dart
@@ -19,7 +19,7 @@ Future<Dio> apiDio(ApiDioRef ref) async {
   final roleInterceptor = await ref.watch(roleInterceptorProvider.future);
   dio.interceptors.add(roleInterceptor);
 
-  final authInterceptor = ref.watch(authInterceptorProvider);
+  final authInterceptor = ref.watch(authInterceptorProvider(dio));
   dio.interceptors.add(authInterceptor);
 
   dio.interceptors.add(const CustomLogInterceptor());

--- a/lib/providers/auth_interceptor_provider.dart
+++ b/lib/providers/auth_interceptor_provider.dart
@@ -46,11 +46,7 @@ Interceptor authInterceptor(AuthInterceptorRef ref, Dio dio) {
   return InterceptorsWrapper(
     onRequest: (options, handler) async {
       final accessToken = await ref.read(accessTokenProvider.future);
-      if (accessToken != null) {
-        options.accessToken = accessToken;
-      }
-
-      return handler.next(options);
+      return handler.next(options..accessToken = accessToken);
     },
     onError: (error, handler) async {
       final statusCode = error.response?.statusCode;
@@ -71,8 +67,12 @@ Interceptor authInterceptor(AuthInterceptorRef ref, Dio dio) {
 }
 
 extension on RequestOptions {
-  set accessToken(String value) {
-    headers["Authorization"] = "Bearer $value";
+  set accessToken(String? value) {
+    if (value != null) {
+      headers["Authorization"] = "Bearer $value";
+    } else {
+      headers.remove("Authorization");
+    }
   }
 
   bool get isTokenRefresh => extra["type"] == "token_refresh";

--- a/lib/providers/auth_interceptor_provider.dart
+++ b/lib/providers/auth_interceptor_provider.dart
@@ -1,18 +1,53 @@
 import 'package:dears/providers/access_token_provider.dart';
 import 'package:dears/providers/auth_state_provider.dart';
-import 'package:dears/providers/refresh_token_provider.dart';
+import 'package:dears/utils/logger.dart';
 import 'package:dio/dio.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'auth_interceptor_provider.g.dart';
 
 @riverpod
-Interceptor authInterceptor(AuthInterceptorRef ref) {
+Interceptor authInterceptor(AuthInterceptorRef ref, Dio dio) {
+  bool isRefreshing = false;
+  final retryQueue = <(RequestOptions, ErrorInterceptorHandler)>[];
+
+  Future<void> handleUnauthorized(
+    RequestOptions options,
+    ErrorInterceptorHandler handler,
+  ) async {
+    retryQueue.add((options, handler));
+    if (isRefreshing) {
+      return;
+    }
+
+    try {
+      isRefreshing = true;
+
+      logger.t("token refreshing");
+      await ref.read(authStateProvider.notifier).refresh();
+
+      for (final (options, handler) in retryQueue) {
+        dio.fetch(options).then(handler.resolve).catchError((e) {
+          if (e is DioException) {
+            handler.next(e);
+          }
+          // ignore other errors
+        });
+      }
+    } on TokenRefreshException catch (_) {
+      logger.i("sign out due to refresh token failure");
+      await ref.read(authStateProvider.notifier).signOut();
+    } finally {
+      retryQueue.clear();
+      isRefreshing = false;
+    }
+  }
+
   return InterceptorsWrapper(
     onRequest: (options, handler) async {
       final accessToken = await ref.read(accessTokenProvider.future);
       if (accessToken != null) {
-        options.headers["Authorization"] = "Bearer $accessToken";
+        options.accessToken = accessToken;
       }
 
       return handler.next(options);
@@ -20,15 +55,14 @@ Interceptor authInterceptor(AuthInterceptorRef ref) {
     onError: (error, handler) async {
       final statusCode = error.response?.statusCode;
       if (statusCode == 401) {
-        final refreshToken = await ref.read(refreshTokenProvider.future);
-        if (refreshToken != null) {
-          await ref.read(authStateProvider.notifier).refresh(refreshToken);
-          final response = await retry(error.requestOptions);
-          return handler.resolve(response);
+        final options = error.requestOptions;
+
+        if (options.isTokenRefresh) {
+          logger.e("failed to refresh tokens, i.e. refresh token is expired");
+          return handler.next(error);
         }
 
-        await ref.read(authStateProvider.notifier).signOut();
-        return handler.next(error);
+        return await handleUnauthorized(options, handler);
       }
 
       return handler.next(error);
@@ -36,6 +70,10 @@ Interceptor authInterceptor(AuthInterceptorRef ref) {
   );
 }
 
-Future<Response> retry(RequestOptions requestOptions) async {
-  return Dio().fetch(requestOptions);
+extension on RequestOptions {
+  set accessToken(String value) {
+    headers["Authorization"] = "Bearer $value";
+  }
+
+  bool get isTokenRefresh => extra["type"] == "token_refresh";
 }

--- a/lib/providers/refresh_token_provider.dart
+++ b/lib/providers/refresh_token_provider.dart
@@ -1,31 +1,15 @@
 import 'package:dears/providers/secure_storage_provider.dart';
+import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'refresh_token_provider.g.dart';
 
-const String _key = "refresh_token";
-
-@riverpod
-class RefreshToken extends _$RefreshToken {
+@Riverpod(keepAlive: true)
+class RefreshToken extends _$RefreshToken with SecureStorageProviderMixin {
+  @protected
   @override
-  Future<String?> build() async {
-    final storage = ref.watch(storageProvider);
-    return storage.read(key: _key);
-  }
+  final key = "refresh_token";
 
-  Future<String?> _save(String? value) async {
-    final storage = ref.read(storageProvider);
-    await storage.write(key: _key, value: value);
-    return value;
-  }
-
-  Future<void> setValue(String value) async {
-    state = const AsyncValue.loading();
-    state = await AsyncValue.guard(() => _save(value));
-  }
-
-  Future<void> clear() async {
-    state = const AsyncValue.loading();
-    state = await AsyncValue.guard(() => _save(null));
-  }
+  @override
+  Future<String?> build();
 }

--- a/lib/providers/secure_storage_provider.dart
+++ b/lib/providers/secure_storage_provider.dart
@@ -7,3 +7,29 @@ part 'secure_storage_provider.g.dart';
 FlutterSecureStorage storage(StorageRef ref) {
   return const FlutterSecureStorage();
 }
+
+mixin SecureStorageProviderMixin on AsyncNotifier<String?> {
+  String get key;
+
+  @override
+  Future<String?> build() async {
+    final storage = ref.read(storageProvider);
+    return storage.read(key: key);
+  }
+
+  Future<String?> _save(String? value) async {
+    final storage = ref.read(storageProvider);
+    await storage.write(key: key, value: value);
+    return value;
+  }
+
+  Future<void> setValue(String value) async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() => _save(value));
+  }
+
+  Future<void> clear() async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() => _save(null));
+  }
+}

--- a/lib/providers/uuid_provider.dart
+++ b/lib/providers/uuid_provider.dart
@@ -1,31 +1,15 @@
 import 'package:dears/providers/secure_storage_provider.dart';
+import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'uuid_provider.g.dart';
 
-const String _key = "uuid";
-
-@riverpod
-class Uuid extends _$Uuid {
+@Riverpod(keepAlive: true)
+class Uuid extends _$Uuid with SecureStorageProviderMixin {
+  @protected
   @override
-  Future<String?> build() async {
-    final storage = ref.watch(storageProvider);
-    return storage.read(key: _key);
-  }
+  final key = "uuid";
 
-  Future<String?> _save(String? value) async {
-    final storage = ref.read(storageProvider);
-    await storage.write(key: _key, value: value);
-    return value;
-  }
-
-  Future<void> setValue(String value) async {
-    state = const AsyncValue.loading();
-    state = await AsyncValue.guard(() => _save(value));
-  }
-
-  Future<void> clear() async {
-    state = const AsyncValue.loading();
-    state = await AsyncValue.guard(() => _save(null));
-  }
+  @override
+  Future<String?> build();
 }

--- a/lib/utils/dio.dart
+++ b/lib/utils/dio.dart
@@ -1,7 +1,0 @@
-import 'package:flutter/foundation.dart';
-import 'package:pretty_dio_logger/pretty_dio_logger.dart';
-
-final logInterceptor = PrettyDioLogger(
-  // ignore: avoid_redundant_argument_values
-  enabled: kDebugMode,
-);

--- a/lib/utils/log_interceptor.dart
+++ b/lib/utils/log_interceptor.dart
@@ -1,0 +1,141 @@
+import 'dart:convert';
+
+import 'package:dears/utils/logger.dart';
+import 'package:dio/dio.dart';
+
+const JsonEncoder _encoder = JsonEncoder.withIndent("  ");
+const String _timestampKey = "_log_timestamp_";
+
+class CustomLogInterceptor extends Interceptor {
+  const CustomLogInterceptor();
+
+  @override
+  void onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) {
+    final buffer = StringBuffer();
+
+    buffer.writeHeaderLine("Request", options);
+    buffer.writeHeaders(options.headers);
+    buffer.writeExtra(options.extra);
+    buffer.writeBody(options.data);
+
+    logger.d(buffer.toString());
+
+    options.extra[_timestampKey] = DateTime.timestamp().millisecondsSinceEpoch;
+
+    handler.next(options);
+  }
+
+  @override
+  void onResponse(
+    Response response,
+    ResponseInterceptorHandler handler,
+  ) {
+    final buffer = StringBuffer();
+
+    final options = response.requestOptions;
+    buffer.writeHeaderLine("Response", options, response);
+    buffer.writeHeaders(response.headers.map);
+    buffer.writeBody(response.data);
+
+    logger.d(buffer.toString());
+
+    handler.next(response);
+  }
+
+  @override
+  void onError(
+    DioException err,
+    ErrorInterceptorHandler handler,
+  ) {
+    final buffer = StringBuffer();
+
+    final type = err.type;
+    final options = err.requestOptions;
+    final response = err.response;
+    if (type == DioExceptionType.badResponse && response != null) {
+      buffer.writeHeaderLine("DioError", options, response);
+      buffer.writeBody(response.data);
+    } else {
+      buffer.writeHeaderLine("DioError-$type", options);
+      buffer.writeln(err.message);
+    }
+
+    logger.e(buffer.toString());
+
+    handler.next(err);
+  }
+}
+
+String _getPath(Uri uri) {
+  final path = uri.path;
+
+  final query = uri.query;
+  if (query.isEmpty) {
+    return path;
+  }
+
+  final decodedQuery = Uri.decodeQueryComponent(query);
+  return "$path?$decodedQuery";
+}
+
+int? _getDiff(Map<String, dynamic> extra) {
+  final requestTime = extra[_timestampKey] as int?;
+  if (requestTime == null) {
+    return null;
+  }
+  return DateTime.timestamp().millisecondsSinceEpoch - requestTime;
+}
+
+extension on StringBuffer {
+  void writeHeaderLine(
+    String prefix,
+    RequestOptions options, [
+    Response? response,
+  ]) {
+    write(prefix);
+
+    if (response != null) {
+      final statusCode = response.statusCode;
+      write(" | $statusCode");
+    }
+
+    final method = options.method;
+    final path = _getPath(options.uri);
+    write(" | $method $path");
+
+    if (response != null) {
+      final diff = _getDiff(options.extra) ?? 0;
+      write(" | Time: $diff ms");
+    }
+
+    writeln();
+  }
+
+  void writeHeaders(Map<String, dynamic> headers) {
+    if (headers.isNotEmpty) {
+      writeln("\n[Headers]");
+      for (final MapEntry(:key, :value) in headers.entries) {
+        writeln("$key: $value");
+      }
+    }
+  }
+
+  void writeExtra(Map<String, dynamic> extra) {
+    if (extra.isNotEmpty) {
+      writeln("\n[Extra]");
+      for (final MapEntry(:key, :value) in extra.entries) {
+        writeln("$key: $value");
+      }
+    }
+  }
+
+  void writeBody(dynamic data) {
+    if (data != null) {
+      writeln("\n[Body]");
+      writeln(_encoder.convert(data));
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -933,14 +933,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
-  pretty_dio_logger:
-    dependency: "direct main"
-    description:
-      name: pretty_dio_logger
-      sha256: "36f2101299786d567869493e2f5731de61ce130faa14679473b26905a92b6407"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.0"
   protobuf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   json_annotation: ^4.9.0
   kakao_flutter_sdk_user: ^1.9.6
   logger: ^2.4.0
-  pretty_dio_logger: ^1.4.0
   retrofit: ^4.1.0
   riverpod_annotation: ^2.3.5
   shared_preferences: ^2.3.1


### PR DESCRIPTION
### PR 요약
- API 통신 로그 개선
- 액세스 토큰 만료 시에 동작하는 토큰 재발급 플로우 개선

### 변경 사항
- `FlutterSecureStorage` 기반으로 저장되는 프로바이더를 `keepAlive`로 변경

### 참고 사항
